### PR TITLE
Add option to disable slow metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Flags:
       --disable-service.dns      Disable the dns service exporter
       --disable-service.baremetal
                                  Disable the baremetal service exporter
-      --disable-service.gnocchi  Disable the gnocchi service exporter
+      --disable-service.gnocchi  Disable the gnocchi service 
+      --disable-slow-metrics     disable slow metrics for performance reasons
       --version                  Show application version.
 
 Args:
@@ -143,17 +144,26 @@ clouds:
 Please fill pull requests or issues under Github. Feel free to request any metrics
 that might be missing.
 
-### Communication
-
-Please join us at #openstack-exporter at Freenode
-
 ## Metrics
 
-The neutron/nova metrics contains the *_state metrics, which are separated
-by service/agent name.
+#### Slow metrics
 
-Please note that by convention resources metrics such as memory or storage are returned in bytes.
+There are some metrics that depending on the cloud deployment size, can be slow to be
+collected because iteration over different projects is required. Those metrics are marked as `slow` and can be disabled with the command
+line parameter `--disable-slow-metrics`.
 
+Currently flagged as slow metrics are:
+
+Name | Exporter
+-----|------------
+limits_vcpus_max | nova
+limits_vcpus_used | nova
+limits_memory_max | nova
+limits_memory_used | nova
+limits_volume_max_gb | cinder
+limits_volume_used_gb |  cinder
+
+#### Metrics collected
 
 Name     | Sample Labels | Sample Value | Description
 ---------|---------------|--------------|------------
@@ -913,3 +923,11 @@ openstack_object_store_up 1
 
 [buildstatus]: https://circleci.com/gh/openstack-exporter/openstack-exporter/tree/master.svg?style=shield
 [circleci]: https://circleci.com/gh/openstack-exporter/openstack-exporter
+
+### Communication
+
+Please join us at #openstack-exporter at Freenode
+
+## Metrics
+
+Please note that by convention resources metrics such as memory or storage are returned in bytes.

--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -60,8 +60,8 @@ var defaultCinderMetrics = []Metric{
 	{Name: "volume_status", Labels: []string{"id", "name", "status", "bootable", "tenant_id", "size", "volume_type"}, Fn: nil},
 	{Name: "pool_capacity_free_gb", Labels: []string{"name", "volume_backend_name", "vendor_name"}, Fn: ListCinderPoolCapacityFree},
 	{Name: "pool_capacity_total_gb", Labels: []string{"name", "volume_backend_name", "vendor_name"}, Fn: nil},
-	{Name: "limits_volume_max_gb", Labels: []string{"tenant", "tenant_id"}, Fn: ListVolumeLimits},
-	{Name: "limits_volume_used_gb", Labels: []string{"tenant", "tenant_id"}, Fn: nil},
+	{Name: "limits_volume_max_gb", Labels: []string{"tenant", "tenant_id"}, Fn: ListVolumeLimits, Slow: true},
+	{Name: "limits_volume_used_gb", Labels: []string{"tenant", "tenant_id"}, Fn: nil, Slow: true},
 }
 
 func NewCinderExporter(config *ExporterConfig) (*CinderExporter, error) {
@@ -73,7 +73,9 @@ func NewCinderExporter(config *ExporterConfig) (*CinderExporter, error) {
 	}
 
 	for _, metric := range defaultCinderMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/containerinfra.go
+++ b/exporters/containerinfra.go
@@ -53,7 +53,9 @@ func NewContainerInfraExporter(config *ExporterConfig) (*ContainerInfraExporter,
 		},
 	}
 	for _, metric := range defaultContainerInfraMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 	return &exporter, nil
 }

--- a/exporters/designate.go
+++ b/exporters/designate.go
@@ -62,7 +62,9 @@ func NewDesignateExporter(config *ExporterConfig) (*DesignateExporter, error) {
 	exporter.Client.MoreHeaders = map[string]string{"X-Auth-All-Projects": "True"}
 
 	for _, metric := range defaultDesignateMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -119,7 +119,7 @@ func (suite *BaseOpenStackTestSuite) SetupTest() {
 
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
 
-	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, func() (string, error) {
+	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, func() (string, error) {
 		return DEFAULT_UUID, nil
 	})
 

--- a/exporters/glance.go
+++ b/exporters/glance.go
@@ -22,7 +22,9 @@ func NewGlanceExporter(config *ExporterConfig) (*GlanceExporter, error) {
 	}
 
 	for _, metric := range defaultGlanceMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/gnocchi.go
+++ b/exporters/gnocchi.go
@@ -25,7 +25,9 @@ func NewGnocchiExporter(config *ExporterConfig) (*GnocchiExporter, error) {
 		},
 	}
 	for _, metric := range defaultGnocchiMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 	return &exporter, nil
 }

--- a/exporters/ironic.go
+++ b/exporters/ironic.go
@@ -26,7 +26,9 @@ func NewIronicExporter(config *ExporterConfig) (*IronicExporter, error) {
 	}
 
 	for _, metric := range defaultIronicMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -33,7 +33,9 @@ func NewKeystoneExporter(config *ExporterConfig) (*KeystoneExporter, error) {
 	}
 
 	for _, metric := range defaultKeystoneMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/neutron.go
+++ b/exporters/neutron.go
@@ -49,7 +49,9 @@ func NewNeutronExporter(config *ExporterConfig) (*NeutronExporter, error) {
 	}
 
 	for _, metric := range defaultNeutronMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -73,10 +73,10 @@ var defaultNovaMetrics = []Metric{
 	{Name: "local_storage_used_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
 	{Name: "server_status", Labels: []string{"id", "status", "name", "tenant_id", "user_id", "address_ipv4",
 		"address_ipv6", "host_id", "hypervisor_hostname", "uuid", "availability_zone", "flavor_id"}},
-	{Name: "limits_vcpus_max", Labels: []string{"tenant", "tenant_id"}, Fn: ListComputeLimits},
-	{Name: "limits_vcpus_used", Labels: []string{"tenant", "tenant_id"}},
-	{Name: "limits_memory_max", Labels: []string{"tenant", "tenant_id"}},
-	{Name: "limits_memory_used", Labels: []string{"tenant", "tenant_id"}},
+	{Name: "limits_vcpus_max", Labels: []string{"tenant", "tenant_id"}, Fn: ListComputeLimits, Slow: true},
+	{Name: "limits_vcpus_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_memory_max", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_memory_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
 }
 
 func NewNovaExporter(config *ExporterConfig) (*NovaExporter, error) {
@@ -87,7 +87,9 @@ func NewNovaExporter(config *ExporterConfig) (*NovaExporter, error) {
 		},
 	}
 	for _, metric := range defaultNovaMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/exporters/objectstore.go
+++ b/exporters/objectstore.go
@@ -24,7 +24,9 @@ func NewObjectStoreExporter(config *ExporterConfig) (*ObjectStoreExporter, error
 	}
 
 	for _, metric := range defaultObjectStoreMetrics {
-		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+		}
 	}
 
 	return &exporter, nil

--- a/main.go
+++ b/main.go
@@ -13,19 +13,21 @@ import (
 )
 
 var defaultEnabledServices = []string{"network", "compute", "image", "volume", "identity", "object-store", "load-balancer", "container-infra", "dns", "baremetal", "gnocchi"}
+
 var DEFAULT_OS_CLIENT_CONFIG = "/etc/openstack/clouds.yaml"
 
 func main() {
 	var (
-		logLevel        = kingpin.Flag("log.level", "Log level: [debug, info, warn, error, fatal]").Default("info").String()
-		bind            = kingpin.Flag("web.listen-address", "address:port to listen on").Default(":9180").String()
-		metrics         = kingpin.Flag("web.telemetry-path", "uri path to expose metrics").Default("/metrics").String()
-		osClientConfig  = kingpin.Flag("os-client-config", "Path to the cloud configuration file").Default(DEFAULT_OS_CLIENT_CONFIG).String()
-		prefix          = kingpin.Flag("prefix", "Prefix for metrics").Default("openstack").String()
-		endpointType    = kingpin.Flag("endpoint-type", "openstack endpoint type to use (i.e: public, internal, admin)").Default("public").String()
-		collectTime     = kingpin.Flag("collect-metric-time", "time spent collecting each metric").Default("false").Bool()
-		disabledMetrics = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
-		cloud           = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").Required().String()
+		logLevel           = kingpin.Flag("log.level", "Log level: [debug, info, warn, error, fatal]").Default("info").String()
+		bind               = kingpin.Flag("web.listen-address", "address:port to listen on").Default(":9180").String()
+		metrics            = kingpin.Flag("web.telemetry-path", "uri path to expose metrics").Default("/metrics").String()
+		osClientConfig     = kingpin.Flag("os-client-config", "Path to the cloud configuration file").Default(DEFAULT_OS_CLIENT_CONFIG).String()
+		prefix             = kingpin.Flag("prefix", "Prefix for metrics").Default("openstack").String()
+		endpointType       = kingpin.Flag("endpoint-type", "openstack endpoint type to use (i.e: public, internal, admin)").Default("public").String()
+		collectTime        = kingpin.Flag("collect-metric-time", "time spent collecting each metric").Default("false").Bool()
+		disabledMetrics    = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
+		disableSlowMetrics = kingpin.Flag("disable-slow-metrics", "disable slow metrics for performance reasons").Default("false").Bool()
+		cloud              = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").Required().String()
 	)
 
 	services := make(map[string]*bool)
@@ -57,7 +59,7 @@ func main() {
 	enabledExporters := 0
 	for service, disabled := range services {
 		if !*disabled {
-			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, nil)
+			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, nil)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				log.Errorf("enabling exporter for service %s failed: %s", service, err)


### PR DESCRIPTION
There are some metrics that depending on the cloud deployment size, can be slow to be collected because iteration over different projects is required. Those metrics are marked as `slow` and can be disabled with the command line parameter `--disable-slow-metrics`.

Related to bug #132